### PR TITLE
Separate duty variables for throttle and mppt

### DIFF
--- a/Motor Controller Firmware/src/core.cpp
+++ b/Motor Controller Firmware/src/core.cpp
@@ -49,11 +49,9 @@ void loop() {
   readInput();
 
   // Update duty pwithout blocking.
-  if (duty<90){
-    if (nonblockingUpdate(pwmUpdate)) {
-      updateDuty();
-      checkProtections();
-    }
+  if (nonblockingUpdate(pwmUpdate)) {
+    updateDuty();
+    checkProtections();
   }
   // Read temperatures without blocking.
   if (nonblockingUpdate(tempUpdate)) {
@@ -77,10 +75,8 @@ void loop() {
 
   // Track MPPT without blocking.
   #if defined(MAX_POWER_POINT_TRACKING)
-    if (duty>=90) {
-      if (nonblockingUpdate(mpptUpdate)) {
-        trackMPPT();
-      }
+    if (nonblockingUpdate(mpptUpdate)) {
+      trackMPPT();
     }
   #endif
   // Send telemetry without blocking.

--- a/Motor Controller Firmware/src/modules/fastpwm.cpp
+++ b/Motor Controller Firmware/src/modules/fastpwm.cpp
@@ -118,7 +118,7 @@ void updateDuty() {
       targetReached = true;
     }
   }
-  if (duty<90) {
+  if (throttleDuty<90) {
     duty = throttleDuty;
   }
 }

--- a/Motor Controller Firmware/src/modules/fastpwm.cpp
+++ b/Motor Controller Firmware/src/modules/fastpwm.cpp
@@ -18,6 +18,8 @@
 
 int duty = 0;     // (%)
 int lastDuty = 0; // (%)
+int throttleDuty = 0; // %
+int lastThrottleDuty = 0; // %
 
 // Configure PWM Zones.
 // pwmConfig pwmZones = {percentMax, prescale, resolution, multiplier};
@@ -107,13 +109,16 @@ void setPWM() {
 void updateDuty() {
   if (!targetReached) {
     if (duty < targetDuty) {
-      duty++;
+      throttleDuty++;
       pwmUpdate.executionInterval = INTERVAL_UP;
     } else if (duty > targetDuty) {
-      duty--;
+      throttleDuty--;
       pwmUpdate.executionInterval = INTERVAL_DOWN;
     } else {
       targetReached = true;
     }
+  }
+  if (duty<90) {
+    duty = throttleDuty;
   }
 }

--- a/Motor Controller Firmware/src/modules/fastpwm.h
+++ b/Motor Controller Firmware/src/modules/fastpwm.h
@@ -21,6 +21,8 @@
 
 extern int duty;        // (%)
 extern int lastDuty;    // (%)
+extern int throttleDuty; // %
+extern int lastThrottleDuty; // %
 
 struct pwmConfig {
   int percentMax;

--- a/Motor Controller Firmware/src/modules/sense.cpp
+++ b/Motor Controller Firmware/src/modules/sense.cpp
@@ -35,6 +35,8 @@ float power;            // (W)
 float lastPower = 0;    // (W)
 float dP = 0;           // (W)
 int it = 1;
+int mpptDuty = duty;
+int lastMPPTduty;
 
 // Setup a oneWire instance to communicate with any OneWire device
 OneWire oneWire(ONE_WIRE_BUS);
@@ -104,16 +106,20 @@ void senseVoltage() {
 
 void sensePower() {
   lastPower = power;
+  lastMPPTduty = mpptDuty;
   power = voltage * current * duty;
 }
 
 void trackMPPT() {
-  dD = duty - lastDuty;
+  dD = mpptDuty - lastMPPTDuty;
   dV = voltage - lastVoltage;
 	if (dP > 0) {
-    duty+=it // keep changing duty in the same direction we were before
+    mpptDuty+=it // keep changing duty in the same direction we were before
   } else {
     it*=-1; // power is decreasing
-    duty+=it;
+    mpptDuty+=it;
+  }
+  if (throttleDuty>=90) {
+    duty = mpptDuty;	  
   }
 }

--- a/Motor Controller Firmware/src/modules/sense.h
+++ b/Motor Controller Firmware/src/modules/sense.h
@@ -38,6 +38,8 @@ extern float power;         // (W)
 extern float lastPower;     // (W) 
 extern float dP;            // (W)
 extern int it;              // increment or decrement of duty
+extern int mpptDuty;        // a %
+extern int lastDuty;        // also a %
 
 extern OneWire oneWire;
 extern DallasTemperature tempSensors;


### PR DESCRIPTION
Allows throttle and mppt to alternate and not interfere with each other.